### PR TITLE
Verify "IOTA Community Governance Vote" result

### DIFF
--- a/results/vote/governance_01.json
+++ b/results/vote/governance_01.json
@@ -1,0 +1,31 @@
+{
+  "milestoneIndex": 3542544,
+  "status": "ended",
+  "questions": [
+    {
+      "answers": [
+        {
+          "value": 1,
+          "current": 372250343375,
+          "accumulated": 30820033631800548
+        },
+        {
+          "value": 2,
+          "current": 74402847655,
+          "accumulated": 6414706069859334
+        },
+        {
+          "value": 0,
+          "current": 0,
+          "accumulated": 0
+        },
+        {
+          "value": 255,
+          "current": 0,
+          "accumulated": 0
+        }
+      ]
+    }
+  ],
+  "checksum": "9d4079c427651060ce2d9bc2b6324725f1d7d6855d14357f6853809a96f84cd6"
+}


### PR DESCRIPTION
We want to verify the outcome of the `IOTA Community Governance Vote` event.

To do this, we need the help of our community node operators who tracked this event.

Please follow the next steps:
- Open a new tab in your browser and go to `http://YOUR-NODE-ADDRESS:14265/api/plugins/participation/events/c8529ff64ea191b437cd625af8b02fd0173bc94aae380ea4cc3367a651536cba/status` (YOUR-NODE-ADDRESS should really be your own node, otherwise we all compare results from the same nodes)
- Check that the `status` of the event is `"ended"`
- Please press "Approve" if your `checksum` matches `9d4079c427651060ce2d9bc2b6324725f1d7d6855d14357f6853809a96f84cd6`. 
![grafik](https://user-images.githubusercontent.com/32371094/160444960-ccf6dedf-df57-4949-9828-131285c66848.png)
